### PR TITLE
Add flag options

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -87,17 +87,17 @@ def validate(gold_file: str, pred_file: str) -> list[str]:
 def main(
     predictions_file: Annotated[
         str,
-        typer.Option(help="Path to the prediction file."),
+        typer.Option("-p", help="Path to the prediction file."),
     ],
     goldstandard_folder: Annotated[
         str,
         typer.Option(
-            help="Path to the folder containing the goldstandard file.",
+            "-g", help="Path to the folder containing the goldstandard file.",
         ),
     ],
     output_file: Annotated[
         str,
-        typer.Option(help="Path to save the results JSON file."),
+        typer.Option("-o", help="Path to save the results JSON file."),
     ] = "results.json",
 ):
     """Validates the predictions file in preparation for evaluation."""


### PR DESCRIPTION
In our execution calls for `validate.py` and `score.py`, we assume there are abbreviated flag names for the parameters: [Example](https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/blob/8204a76ea88cee7f7efd4f58db47d9587c9f0afc/modules/validate_model_to_data.nf#L20)

So I propose to introduce them here. If you'd rather we change things on our end so it's more explicit, we can do that instead.