### PR TITLE
[feat] Enhance `score.py` robustness with default results dictionary

### DIFF
--- a/score.py
+++ b/score.py
@@ -112,6 +112,12 @@ def main(
             "validation_errors": "",
         }
 
+    if not res.get("validation_status"):
+        print(
+            "Validation results not found. Proceeding with scoring but "
+            "results may be inaccurate."
+        )
+
     # Do not attempt to score if previous validations failed. Otherwise,
     # proceed with evaluating predictions.
     if res.get("validation_status") == "INVALID":
@@ -122,8 +128,9 @@ def main(
             scores = score(gold_file, predictions_file)
             status = "SCORED"
             errors = ""
-        except ValueError:
+        except ValueError as err:
             errors = "Error encountered during scoring; submission not evaluated."
+            print(f"Error encountered: {err}")
 
     res |= {
         "score_status": status,

--- a/score.py
+++ b/score.py
@@ -112,6 +112,8 @@ def main(
             "validation_errors": "",
         }
 
+    # Notify that absent validation results may lead to inaccurate scores
+    # (e.g., due to multiple predictions per ID, missing predictions, etc).
     if not res.get("validation_status"):
         print(
             "Validation results not found. Proceeding with scoring but "

--- a/score.py
+++ b/score.py
@@ -112,7 +112,11 @@ def main(
             "validation_errors": "",
         }
 
-    if res.get("validation_status") == "VALIDATED":
+    # Do not attempt to score if previous validations failed. Otherwise,
+    # proceed with evaluating predictions.
+    if res.get("validation_status") == "INVALID":
+        errors = "Submission could not be evaluated due to validation errors."
+    else:
         gold_file = extract_gs_file(goldstandard_folder)
         try:
             scores = score(gold_file, predictions_file)
@@ -120,8 +124,6 @@ def main(
             errors = ""
         except ValueError:
             errors = "Error encountered during scoring; submission not evaluated."
-    else:
-        errors = "Submission could not be evaluated due to validation errors."
 
     res |= {
         "score_status": status,

--- a/score.py
+++ b/score.py
@@ -103,8 +103,14 @@ def main(
 
     scores = {}
     status = "INVALID"
-    with open(output_file, encoding="utf-8") as out:
-        res = json.load(out)
+    try:
+        with open(output_file, encoding="utf-8") as out:
+            res = json.load(out)
+    except (FileNotFoundError, json.decoder.JSONDecodeError):
+        res = {
+            "validation_status": "",
+            "validation_errors": "",
+        }
 
     if res.get("validation_status") == "VALIDATED":
         gold_file = extract_gs_file(goldstandard_folder)


### PR DESCRIPTION
Currently, `score.py` expects the same results JSON file used by `validate.py`. 

To add robustness, a default empty results dictionary (containing empty `validation_status` and `validation_errors`) has been implemented to prevent potential errors if a different or missing results file is provided.